### PR TITLE
Config lib was not there in the Requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -10,3 +10,4 @@ clearbit
 bs4
 lxml
 tqdm
+config


### PR DESCRIPTION
config was not installed when ran pip install -r requirements.txt So adding config to the list.
