### PR TITLE
Htbridge patch

### DIFF
--- a/domain_sslinfo.py
+++ b/domain_sslinfo.py
@@ -4,43 +4,45 @@ import requests
 from bs4 import BeautifulSoup
 import re
 from termcolor import colored
+import time
+
 class style:
    BOLD = '\033[1m'
    END = '\033[0m'
 
-def check_ssl_htbsecurity(domain):
+def check_ssl_htbsecurity(domain, token='', ip=''):
+	global timestamp
 	headers = {}
 	headers['Content-Type'] = "application/x-www-form-urlencoded"
-	data='domain=%s&dnsr=off&recheck=false' % domain
-	req = requests.post('https://www.htbridge.com/ssl/chssl/1451425590.html', headers=headers , data=data)
-	results = json.loads(req.content)
-	return results
+	if token == '':
+		data='domain=%s&show_test_results=true&recheck=false&verbosity=1' % domain
+		url = 'https://www.htbridge.com/ssl/api/v1/check/' + str(timestamp) + '.html'
+		req = requests.post(url, headers=headers , data=data, verify=False)
+		results = json.loads(req.content)
+		return results
+	else:
+		data='domain=' + str(domain) + '&show_test_results=true&recheck=false&choosen_ip=' + str(ip) + '&verbosity=1&token=' + str(token)
+		url = 'https://www.htbridge.com/ssl/api/v1/check/' + str(timestamp) + '.html'
+		req = requests.post(url, headers=headers , data=data, verify=False)
+		results = json.loads(req.content)
+		return results
 
 def main():
 	domain = sys.argv[1]
 	results = check_ssl_htbsecurity(domain)
-	if 'ERROR' in results.keys():
-		print results['ERROR']
-	elif 'TOKEN' in results.keys():
+	if 'error' in results.keys():
+		print results['error']
+	elif 'token' in results.keys():
 		print colored('Picking up One IP from bunch of IPs returned: %s', 'blue') % results['MULTIPLE_IPS'][0]
-		results_new = check_ssl_htbsecurity(results['MULTIPLE_IPS'][0])
-		print "OverAll Rating: %s" % results_new['GRADE']
+		token = results['token']
+		results_new = check_ssl_htbsecurity(domain, token, results['multiple_ips'][0])
+		print "OverAll Rating: %s" % results_new['results']['grade']
 		print 'Check https://www.htbridge.com/ssl/ for more information'
-		for x in results_new['VALUE'].keys():
-			if str("[5]") in str(results_new['VALUE'][x]) or str("[3]") in str(results_new['VALUE'][x]):
-				if x == 'httpHeaders':
-					pass
-				else:
-					print results_new['VALUE'][x]
-	else:
-		print "OverAll Rating: %s" % results['GRADE']
-		for x in results['VALUE'].keys():
-			if str("[5]") in str(results['VALUE'][x]) or str("[3]") in str(results['VALUE'][x]):
-				if x == 'httpHeaders':
-					pass
-				else:
-					print results['VALUE'][x]
+
+#Added unix timestamp instead of using the same time stamp given in the example. This is done to prevent caching on client side. For more details refer: https://www.htbridge.com/ssl/#api
 
 if __name__ == "__main__":
+	global timestamp;
+	timestamp = int(time.time())
 	main()
 


### PR DESCRIPTION
**Additions:**
* Added timestamp instead of hardcoded value to avoid caching on client
side
* imported time module
* Changed the syntax of check_ssl_htbsecurity so that the token value
could also be passed from the second time

**Deletions:**
* Didnt understand what str("[3]") and str("[5]") refers to. Now the API
response has been completely changed, so I have no idea about that and
just deleted the part

**Upcoming / Suggestions:**
* Instead of checking just one ip of the domain, its good to check all
the IPs, so that if any domain is mismatching, its a good sign.
* Will add expires soon notification and the expiry date in future.