### PR TITLE
README.md is misleading

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,11 +37,9 @@ Options:
 ```
 
 # Required Setup:
-* Python 2.7 (because bunch of dependencies do not support Python 3.0)
-* Bunch of python libraries (use requirements.txt)
+* Python 2.7 (because dependency [`python-Wappalyzer`](https://github.com/chorsley/python-Wappalyzer) does not support Python 3.0)
+* Bunch of python libraries (use `pip install -r requirements.txt`)
 
 
 ## Detailed Tool Documentation:
 > [http://datasploit.readthedocs.io/en/latest/](http://datasploit.readthedocs.io/en/latest/)
-
-

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Options:
 
 # Required Setup:
 * Python 2.7 (because dependency [`python-Wappalyzer`](https://github.com/chorsley/python-Wappalyzer) does not support Python 3)
-* Bunch of python libraries (use `pip install -r requirements.txt`)
+* Bunch of Python libraries (use `pip install -r requirements.txt`)
 
 
 ## Detailed Tool Documentation:

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Options:
 ```
 
 # Required Setup:
-* Python 2.7 (because dependency [`python-Wappalyzer`](https://github.com/chorsley/python-Wappalyzer) does not support Python 3.0)
+* Python 2.7 (because dependency [`python-Wappalyzer`](https://github.com/chorsley/python-Wappalyzer) does not support Python 3)
 * Bunch of python libraries (use `pip install -r requirements.txt`)
 
 


### PR DESCRIPTION
All other Python libraries in [requirements.txt](../requirements.txt) support Python 3.

Given that #25 has been open for more than a year, perhaps [`python-Wappalyzer`](https://github.com/chorsley/python-Wappalyzer) is dependency that needs investigation.