### PR TITLE
Restoring CNAME entry

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,0 +1,1 @@
+www.datasploit.info


### PR DESCRIPTION
CNAME entry was last time deleted in https://github.com/DataSploit/datasploit/commit/437d95598a05ed228debe4e20f131fe13a9ce2b3 restoring it back.