### PR TITLE
Setup JSON output for domains scripts

### DIFF
--- a/domain/domain_dnsrecords.py
+++ b/domain/domain_dnsrecords.py
@@ -1,11 +1,13 @@
 #!/usr/bin/env python
 
+import json
 import base
 import sys
 import dns.resolver
 from termcolor import colored
 
 ENABLED = True
+OUTPUT_TYPE = "console"
 
 
 class style:
@@ -18,11 +20,13 @@ def fetch_dns_records(domain, rec_type):
         answers = dns.resolver.query(domain, rec_type)
         rec_list = []
         for rdata in answers:
-            rec_list.append(rdata)
+            rec_list.append(rdata.to_text())
         return rec_list
     except:
-        return colored("No Records Found", 'red')
-
+        if(OUTPUT_TYPE == "console"):
+            return colored("No Records Found", 'red')
+        if(OUTPUT_TYPE == "json"):
+            return list()
 
 def parse_dns_records(domain):
     dict_dns_record = {}
@@ -37,7 +41,8 @@ def parse_dns_records(domain):
 
 
 def banner():
-    print colored(style.BOLD + '---> Finding DNS Records.\n' + style.END, 'blue')
+    if(OUTPUT_TYPE == "console"):
+        print colored(style.BOLD + '---> Finding DNS Records.\n' + style.END, 'blue')
 
 
 def main(domain):
@@ -45,19 +50,26 @@ def main(domain):
 
 
 def output(data, domain=""):
-    for x in data.keys():
-        print x
-        if "No" in data[x] and "Found" in data[x]:
-            print "\t%s" % data[x]
-        else:
-            for y in data[x]:
-                print "\t%s" % y
-    print "\n-----------------------------\n"
+    if(OUTPUT_TYPE == "console"):
+        for x in data.keys():
+            print x
+            if "No" in data[x] and "Found" in data[x]:
+                print "\t%s" % data[x]
+            else:
+                for y in data[x]:
+                    print "\t%s" % y
+        print "\n-----------------------------\n"
+
+    if(OUTPUT_TYPE == "json"):
+        print(json.dumps(data))
 
 
 if __name__ == "__main__":
     try:
         domain = sys.argv[1]
+        if(len(sys.argv) > 2):
+            OUTPUT_TYPE = sys.argv[2]
+
         banner()
         result = main(domain)
         output(result, domain)

--- a/domain/domain_whois.py
+++ b/domain/domain_whois.py
@@ -1,40 +1,58 @@
 #!/usr/bin/env python
 
+import json
 import base
 import sys
 import whois
 from termcolor import colored
 import time
+import datetime
 
 ENABLED = True
-
+OUTPUT_TYPE = "console"
 
 class style:
     BOLD = '\033[1m'
     END = '\033[0m'
 
-
 def whoisnew(domain):
     w = whois.whois(domain)
     return dict(w)
 
-
 def banner():
-    print colored(style.BOLD + '---> Finding Whois Information.' + style.END, 'blue')
-
+    if(OUTPUT_TYPE == "console"):
+        print colored(style.BOLD + '---> Finding Whois Information.' + style.END, 'blue')
 
 def main(domain):
     return whoisnew(domain)
 
-
 def output(data, domain=""):
-    print data
-    print "\n-----------------------------\n"
 
+    if(OUTPUT_TYPE == "console"):
+        print data
+        print "\n-----------------------------\n"
+
+    if(OUTPUT_TYPE == "json"):
+        js = {}
+        for i in data:
+            # convert iterables to json list
+            if(hasattr(data[i], '__iter__')):
+                js[i] = list()
+                for j in data[i]:
+                    js[i].append(j)
+            # convert datetime to string
+            elif (isinstance(data[i], datetime.datetime)):
+                js[i] = data[i].strftime("%s")
+            else:
+                js[i] = str(data[i])
+        
+        print json.dumps(js)
 
 if __name__ == "__main__":
     try:
         domain = sys.argv[1]
+        if(len(sys.argv) > 2):
+             OUTPUT_TYPE=sys.argv[2]
         banner()
         result = main(domain)
         output(result, domain)


### PR DESCRIPTION
Hi,

I've started to add some custom output (JSON) for standalone scripts to address the issue #174.
It should be easy to plug other outputs formats like  HTML, XML or maybe CSV....

Is this the correct way to implement this ?
I have only done 2 of the domain script to be sure that's the right thing to do before commiting more.

Each of theses scripts got one new arg : the output format. (only applicable if using them as standalone atm. Passing this argument to the runner should probably be implemented after that)

By default, it is set to `console`, with colors outputs and ascii arts enabled.
You can set it to `json` to get a clean json output (pipeable into jq for example)

Example usage : 

```
root@ce7d518eee74:/opt/datasploit# python domain/domain_whois.py example.com json
{"updated_date": "1502694243", "status": ["clientDeleteProhibited https://icann.org/epp#clientDeleteProhibited", "clientTransferProhibited https://icann.org/epp#clientTransferProhibited", "clientUpdateProhibited https://icann.org/epp#clientUpdateProhibited"], "zipcode": "None", "name": "None", "dnssec": "signedDelegation", "city": "None", "expiration_date": "1534132800", "domain_name": "EXAMPLE.COM", "creation_date": "808372800", "whois_server": "whois.iana.org", "state": "None", "registrar": "RESERVED-Internet Assigned Numbers Authority", "referral_url": "None", "address": "None", "name_servers": ["A.IANA-SERVERS.NET", "B.IANA-SERVERS.NET"], "org": "None", "country": "None", "emails": "None"}
```

Feedback very welcome !