### PR TITLE
Osint runner fixes and cleanup

### DIFF
--- a/osint_runner.py
+++ b/osint_runner.py
@@ -29,17 +29,17 @@ def run(component, module_dir, m_input, output = None):
         data = x.main(m_input)
         if data:
             x.output(data, m_input)
-	if output and str(output).upper() == "JSON":
-		json_output[name] = data
+        if output and str(output).upper() == "JSON":
+            json_output[name] = data
 
     if output and str(output).upper() == "JSON":
-	timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
-	filename = "datasploit_%s_%s_%s.json" % (module_dir, m_input, timestamp)
-	filepath = "reports/json"
-	if not os.path.exists(filepath):
-		os.makedirs(filepath)
-	fh = open("%s/%s" % (filepath, filename), "w")
-	fh.write(json.dumps(json_output, default=json_util.default, indent = 4))
-	fh.close()
-	print "JSON report saved to %s/%s" % (filepath, filename)
-	
+        timestamp = datetime.now().strftime("%Y-%m-%d_%H-%M-%S")
+        filename = "datasploit_%s_%s_%s.json" % (module_dir, m_input, timestamp)
+        filepath = "reports/json"
+        if not os.path.exists(filepath):
+            os.makedirs(filepath)
+        file = "%s/%s" % (filepath, filename)
+        fh = open("%s/%s" % (filepath, filename), "w")
+        fh.write(json.dumps(json_output, default=json_util.default, indent = 4))
+        fh.close()
+        print "JSON report saved to %s/%s" % (filepath, filename)

--- a/osint_runner.py
+++ b/osint_runner.py
@@ -5,7 +5,6 @@ import json
 from glob import glob
 from collections import OrderedDict
 from datetime import datetime
-from bson import json_util
 
 
 def run(component, module_dir, m_input, output = None):
@@ -39,7 +38,6 @@ def run(component, module_dir, m_input, output = None):
         if not os.path.exists(filepath):
             os.makedirs(filepath)
         file = "%s/%s" % (filepath, filename)
-        fh = open("%s/%s" % (filepath, filename), "w")
-        fh.write(json.dumps(json_output, default=json_util.default, indent = 4))
-        fh.close()
+        with open(file, "w") as fh:
+            json.dump(json_output, fh, indent=4, sort_keys=True)
         print "JSON report saved to %s/%s" % (filepath, filename)


### PR DESCRIPTION
This cleans up osint_runner.py by nuking tabs in favor of spaces (as is the norm across most of the other modules) and cleaning up/removing the use of bson to write the json outfile.