### PR TITLE
JSON output: make sure domain output is serializable.

### DIFF
--- a/domain/domain_dnsrecords.py
+++ b/domain/domain_dnsrecords.py
@@ -49,6 +49,7 @@ def output(data, domain=""):
         print x
         if "No" in data[x] and "Found" in data[x]:
             print "\t%s" % data[x]
+            data[x] = ''
         else:
             for y in data[x]:
                 try:

--- a/domain/domain_dnsrecords.py
+++ b/domain/domain_dnsrecords.py
@@ -18,7 +18,7 @@ def fetch_dns_records(domain, rec_type):
         answers = dns.resolver.query(domain, rec_type)
         rec_list = []
         for rdata in answers:
-            rec_list.append(rdata)
+            rec_list.append(str(rdata))
         return rec_list
     except:
         return colored("No Records Found", 'red')

--- a/domain/domain_whois.py
+++ b/domain/domain_whois.py
@@ -28,9 +28,12 @@ def main(domain):
 
 
 def output(data, domain=""):
-    data['creation_date'] = data['creation_date'].strftime('%m/%d/%Y')
-    data['expiration_date'] = data['expiration_date'].strftime('%m/%d/%Y')
-    data['updated_date'] = data['updated_date'].strftime('%m/%d/%Y')
+    if 'creation_date' in data:
+        data['creation_date'] = data['creation_date'].strftime('%m/%d/%Y')
+    if 'creation_date' in data:
+        data['expiration_date'] = data['expiration_date'].strftime('%m/%d/%Y')
+    if 'creation_date' in data:
+        data['updated_date'] = data['updated_date'].strftime('%m/%d/%Y')
     print data
     print "\n-----------------------------\n"
 

--- a/domain/domain_whois.py
+++ b/domain/domain_whois.py
@@ -28,6 +28,9 @@ def main(domain):
 
 
 def output(data, domain=""):
+    data['creation_date'] = data['creation_date'].strftime('%m/%d/%Y')
+    data['expiration_date'] = data['expiration_date'].strftime('%m/%d/%Y')
+    data['updated_date'] = data['updated_date'].strftime('%m/%d/%Y')
     print data
     print "\n-----------------------------\n"
 


### PR DESCRIPTION
These commit's fix up a couple areas of output in domain modules that weren't json serializable. 

## Domain Whois Module

### Trying to write datetime objects instead of strings.

The whois python module converts all dates into datetime objects, this is not json serializable, so lets conevert it back to human readable and json serializable, if they exist.

#### Pre Patch Issue
```
Traceback (most recent call last):
  File "datasploit.py", line 89, in <module>
    main(sys.argv[1:])
  File "datasploit.py", line 79, in main
    domainOsint.run(user_input, output)
  File "datasploit/domainOsint.py", line 9, in run
    osint_runner.run("domain", "domain", domain, output)
  File "datasploit/osint_runner.py", line 49, in run
    json.dump(json_output, fh, indent=4, sort_keys=True)
  File "/usr/lib/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/usr/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: datetime.datetime(2007, 12, 7, 1, 48, 54) is not JSON serializable
```
JSON Value trying to be written: `'updated_date': datetime.datetime(2017, 9, 8, 15, 45, 6), u'status'`

#### Post Patch Output

JSON Value Trying to be written: ` 'updated_date': '09/08/2017'`

---

## Domain DNS Records Module

### Trying to write class objects instead of class strings.

Similar issue to whois, we are outputting (and attempting to write) a class object to console/file instead of the class string that we care about. This is deceptive though, because when executing `print $class`, python prints the `$class` string, however in other circumstances it uses the entire object. So, let's just capture the class string and drop the rest of the data that we don't need.

#### Pre Patch Issue

```
Traceback (most recent call last):
  File "datasploit.py", line 89, in <module>
    main(sys.argv[1:])
  File "datasploit.py", line 79, in main
    domainOsint.run(user_input, output)
  File "datasploit/domainOsint.py", line 9, in run
    osint_runner.run("domain", "domain", domain, output)
  File "datasploit/osint_runner.py", line 49, in run
    json.dump(json_output, fh, indent=4, sort_keys=True)
  File "/usr/lib/python2.7/json/__init__.py", line 189, in dump
    for chunk in iterable:
  File "/usr/lib/python2.7/json/encoder.py", line 434, in _iterencode
    for chunk in _iterencode_dict(o, _current_indent_level):
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 408, in _iterencode_dict
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 332, in _iterencode_list
    for chunk in chunks:
  File "/usr/lib/python2.7/json/encoder.py", line 442, in _iterencode
    o = _default(o)
  File "/usr/lib/python2.7/json/encoder.py", line 184, in default
    raise TypeError(repr(o) + " is not JSON serializable")
TypeError: <DNS IN A rdata: xxx.xx.xx.xxx> is not JSON serialize
```

JSON Value trying to be written: `"A Records": [<DNS IN A rdata: xxx.xx.xx.xxx>]`

#### Post Patch Output

JSON Value Trying to be written:  `"A Records": ["xxx.xx.xx.xxx"]`

### "No Records Found" data being written to file

Let's just remove empty records like we (I?) try to do with the other modules/datepoints.

Pre Patch JSON Value: `"AAAA Records": "\u001b[31mNo Records Found\u001b[0m", `

Post Patch JSON Value: `"AAAA Records": "", `