### PR TITLE
datasploit: option for file input

### DIFF
--- a/datasploit.py
+++ b/datasploit.py
@@ -16,22 +16,23 @@ from netaddr import IPAddress,AddrFormatError
 
 def main(argv):
     output=None
-    desc="""                                                           
+    desc="""
    ____/ /____ _ / /_ ____ _ _____ ____   / /____   (_)/ /_
   / __  // __ `// __// __ `// ___// __ \ / // __ \ / // __/
- / /_/ // /_/ // /_ / /_/ /(__  )/ /_/ // // /_/ // // /_  
- \__,_/ \__,_/ \__/ \__,_//____// .___//_/ \____//_/ \__/  
-                               /_/                         
-                                                           
-            Open Source Assistant for #OSINT               
-                www.datasploit.info                                                           
+ / /_/ // /_/ // /_ / /_/ /(__  )/ /_/ // // /_/ // // /_
+ \__,_/ \__,_/ \__/ \__,_//____// .___//_/ \____//_/ \__/
+                               /_/
+
+            Open Source Assistant for #OSINT
+                www.datasploit.info
 
     """
-    epilog="""              Connect at Social Media: @datasploit                  
+    epilog="""              Connect at Social Media: @datasploit
                 """
     # Set all parser arguments here.
     parser = argparse.ArgumentParser(formatter_class=argparse.RawDescriptionHelpFormatter,description=textwrap.dedent(desc),epilog=epilog)
-    parser.add_argument("-i","--input",help="Provide Input",dest='target',required=True)
+    parser.add_argument("-i","--input",help="Provide Input",dest='single_target')
+    parser.add_argument("-f","--file",help="Provide Input",dest='file_target')
     parser.add_argument("-a","--active",help="Run Active Scan attacks",dest='active',action="store_false")
     parser.add_argument("-q","--quiet",help="Run scans in automated manner accepting default answers",dest='quiet',action="store_false")
     parser.add_argument("-o","--output",help="Provide Destination Directory",dest='output')
@@ -45,45 +46,64 @@ def main(argv):
         shutil.copyfile(config_sample_path,config_file_path)
         print "[+] A config file is added please follow guide at https://datasploit.github.io/datasploit/apiGeneration/ to fill API Keys for better results"
         # We can think about quiting at this point.
-    # if no argument is provided print help and quit
-    if len(argv) == 0:
-        parser.print_help()
-        sys.exit()
     # parse arguments in case they are provided.
     x=parser.parse_args()
     active=x.active
     quiet=x.quiet
-    user_input=x.target
+    single_input=x.single_target
+    file_input=x.file_target
     output=x.output
+    # if no target is provided print help and quit.
+    if not (single_input or file_input):
+        print "\nSingle target or file input requered to run\n"
+        parser.print_help()
+        sys.exit()
     # Banner print
     print textwrap.dedent(desc)
-    # Auto selection logic
-    try:    
-        print "User Input: %s" % user_input
+    if single_input:
         try:
-            inp=IPAddress(user_input);
-            if inp.is_private() or inp.is_loopback():
-                print "Internal IP Detected : Skipping"
-                sys.exit()
+            auto_select_target(single_input, output)
+        except KeyboardInterrupt:
+            print "\nCtrl+C called Quiting"
+    if file_input:
+        try:
+            if os.path.isfile(file_input):
+                print "File Input: %s" % file_input
+                with open(file_input, 'r') as f:
+                    for target in f:
+                        auto_select_target(target.rstrip(), output)
+                print "\nDone processing %s" % file_input
             else:
-                print "Looks like an IP, running ipOsint...\n"
-                ipOsint.run(user_input, output)
-        except SystemExit:
-            print "exiting"
-        except AddrFormatError:
-            if re.match('[^@]+@[^@]+\.[^@]+', user_input):
-                print "Looks like an EMAIL, running emailOsint...\n"
-                emailOsint.run(user_input, output)
-            elif get_tld(user_input, fix_protocol=True,fail_silently=True) is not None:
-                print "Looks like a DOMAIN, running domainOsint...\n"
-                domainOsint.run(user_input, output)
-            else:
-                print "Nothing Matched assuming username, running usernameOsint...\n"
-                usernameOsint.run(user_input, output)
-        except:
-            print "Unknown Error Occured"
-    except KeyboardInterrupt:
-        print "Ctrl+C called Quiting"
+                print "%s is not a readable file" % file_input
+                print "Exiting..."
+        except KeyboardInterrupt:
+            print "\nCtrl+C called Quiting"
+
+def auto_select_target(target, output=None):
+    """Auto selection logic"""
+    print "Target: %s" % target
+    try:
+        inp=IPAddress(target);
+        if inp.is_private() or inp.is_loopback():
+            print "Internal IP Detected : Skipping"
+            sys.exit()
+        else:
+            print "Looks like an IP, running ipOsint...\n"
+            ipOsint.run(target, output)
+    except SystemExit:
+        print "exiting"
+    except AddrFormatError:
+        if re.match('[^@]+@[^@]+\.[^@]+', target):
+            print "Looks like an EMAIL, running emailOsint...\n"
+            emailOsint.run(target, output)
+        elif get_tld(target, fix_protocol=True,fail_silently=True) is not None:
+            print "Looks like a DOMAIN, running domainOsint...\n"
+            domainOsint.run(target, output)
+        else:
+            print "Nothing Matched assuming username, running usernameOsint...\n"
+            usernameOsint.run(target, output)
+    except:
+        print "Unknown Error Occured"
 
 if __name__ == "__main__":
    main(sys.argv[1:])

--- a/datasploit.py
+++ b/datasploit.py
@@ -55,7 +55,7 @@ def main(argv):
     output=x.output
     # if no target is provided print help and quit.
     if not (single_input or file_input):
-        print "\nSingle target or file input requered to run\n"
+        print "\nSingle target or file input required to run\n"
         parser.print_help()
         sys.exit()
     # Banner print


### PR DESCRIPTION
This introduces the `-f` flag for file input source. The file needs to be a list of single target per line. The contents of the file can be a mixture of any of the currently allowed data types and will just run through them one at a time. This patch allows for both the `-i` and `-f` options to be called at the same time. Why someone would want to run through a text file of targets and manually specifying another at the same time is beyond me. But, allowing for this does not cause any issues so I figure why not allow it.

This removes the -i option from being required and updates the `if len(argv) == 0:` check to confirm that at least `-i` or `-f` were invoked.

Also, nuke some unnecessary whitespace.