### PR TITLE
add empty subdomains if there is no result key

### DIFF
--- a/domain/domain_subdomains.py
+++ b/domain/domain_subdomains.py
@@ -157,6 +157,8 @@ def subdomains_from_dnstrails(domain, subdomain_list):
     req = requests.get(url, headers=headers)
     if req.status_code == 200:
         data = json.loads(req.text)
+        if 'result' not in data:
+            data['result'] = {'subdomains':''}
         if 'subdomains' in data['result'] and len(data['result']['subdomains']) != 0:
             subdomains_new = data['result']['subdomains']
             for a in range(0, len(subdomains_new)):


### PR DESCRIPTION
```
 [+] Extracting subdomains from DNSTrails

Traceback (most recent call last):
  File "datasploit.py", line 112, in <module>
    main(sys.argv[1:])
  File "datasploit.py", line 68, in main
    auto_select_target(single_input, output)
  File "datasploit.py", line 104, in auto_select_target
    domainOsint.run(target, output)
  File "/l33t/tools/datasploit/domainOsint.py", line 9, in run
    osint_runner.run("domain", "domain", domain, output)
  File "/l33t/tools/datasploit/osint_runner.py", line 28, in run
    data = x.main(m_input)
  File "/l33t/tools/datasploit/domain/domain_subdomains.py", line 181, in main
    subdomain_list = subdomains_from_dnstrails(domain, subdomain_list)
  File "/l33t/tools/datasploit/domain/domain_subdomains.py", line 160, in subdomains_from_dnstrails
    if 'subdomains' in data['result'] and len(data['result']['subdomains']) != 0:
KeyError: 'result'
```
the error occur when running with input single target ``python datasploit.py -i targetdomain`` it seems like when dnstrails cannot find any sub-domains in the target, the ``result`` key in ``data`` variable is not exist so it fails when checking ``subdomains`` key