### PR TITLE
Installing missing dependencies automatically, thanks to @Chan9390

### DIFF
--- a/dep_check.py
+++ b/dep_check.py
@@ -15,6 +15,9 @@ def check_dependency():
             missing_deps.append(req_dep)
 
     if missing_deps:
-        print "You are missing a module for Datasploit. Please install them using: "
-        print "pip install -r requirements.txt"
+        import os
+        dependecy = 'pip install '
+        for dep in missing_deps:
+            dependecy += dep + ' '
+        os.system(dependecy)
         sys.exit()


### PR DESCRIPTION
Installing missing dependencies automatically via dep_check.py file. instead of telling the user to retype the command to install it.