### PR TITLE
Wikileaks crash patch

### DIFF
--- a/domain/domain_wikileaks.py
+++ b/domain/domain_wikileaks.py
@@ -39,7 +39,8 @@ def main(domain):
 
 def output(data, domain=""):
     for tl, lnk in data.items():
-        print "%s (%s)" % (lnk, tl)
+        print "%s (%s)" % (repr(lnk), tl)
+    print ""
     print "For all results, visit: " + 'https://search.wikileaks.org/?query=&exact_phrase=%s&include_external_sources=True&order_by=newest_document_date' % domain
     print "\n-----------------------------\n"
 
@@ -53,4 +54,3 @@ if __name__ == "__main__":
     except Exception as e:
         print e
         print "Please provide a domain name as argument"
-        


### PR DESCRIPTION
Hey,

When I executed Datasploit against a domain, the `domain_wikileaks.py` crashed with the following details:

```
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 16: ordinal not in range(128)
```
This was because the returned URL was having **`\x`** character which made python think that it was hex char and crashed.

My patch was to add `repr()` function around `lnk` variable.

(I also added a print statement so that the wikileaks link can be seen by user :smile: )