### PR TITLE
Update depcheck feature for more accurate comparation

### DIFF
--- a/dep_check.py
+++ b/dep_check.py
@@ -11,8 +11,26 @@ def check_dependency():
     pip_list = sorted([(i.key) for i in pip.get_installed_distributions()])
 
     for req_dep in list_deps:
-        if req_dep not in pip_list:
-            missing_deps.append(req_dep)
+        compare_char = ["==", ">=", "<=", ">", "<", "!="]
+        for c in compare_char:
+            if c in req_dep:
+                pkg = req_dep.split(c)
+                if pkg[0] not in pip_list:
+                    missing_deps.append(req_dep)
+                    break
+                else:
+                    installed_ver = pkg_resources.get_distribution(pkg[0]).version
+                    if self.get_truth(installed_ver, c, pkg[1]):
+                        break
+                    else:
+                        missing_deps.append(req_dep)                            
+            else:
+                if req_dep not in pip_list:
+                    # Why this package is not in get_installed_distributions ?
+                    if str(req_dep) == "argparse":
+                        pass
+                    else:
+                        missing_deps.append(req_dep)
 
     if missing_deps:
         print "You are missing a module for Datasploit. Please install them using: "


### PR DESCRIPTION
Hi there,

I've updating depcheck feature for my Belati plugin so it will be more accurate if you use version system in requirements.txt for depcheck. I've tested in Belati and running well. Now, you can try to use specific version for each package, example:

django==1.11.6

Reference to this PR https://github.com/aancw/Belati/pull/26 and this issue https://github.com/aancw/Belati/issues/25

Thanks, 