### PR TITLE
Clearbit API v1 -> v2

### DIFF
--- a/emails/email_clearbit.py
+++ b/emails/email_clearbit.py
@@ -8,7 +8,7 @@ import json
 from termcolor import colored
 
 # Control whether the module is enabled or not
-ENABLED = False
+ENABLED = True
 
 
 class style:
@@ -24,7 +24,7 @@ def main(email):
     clearbit_apikey = vault.get_key('clearbit_apikey')
     if clearbit_apikey != None:
         headers = {"Authorization": "Bearer %s" % clearbit_apikey}
-        req = requests.get("https://person.clearbit.com/v1/people/email/%s" % (email), headers=headers)
+        req = requests.get("https://person-stream.clearbit.com/v2/people/find?email=%s" % (email), headers=headers)
         person_details = json.loads(req.content)
         if "error" in req.content and "queued" in req.content:
             print "This might take some more time, Please run this script again, after 5 minutes."

--- a/emails/email_slideshare.py
+++ b/emails/email_slideshare.py
@@ -20,12 +20,15 @@ def banner():
 
 
 def main(email):
-    req = requests.get('http://www.slideshare.net/search/slideshow?q=%s' % (email))
-    soup = BeautifulSoup(req.content, "lxml")
-    atag = soup.findAll('a', {'class': 'title title-link antialiased j-slideshow-title'})
     slides = {}
-    for at in atag:
-        slides[at.text] = at['href']
+    try:
+        req = requests.get('http://www.slideshare.net/search/slideshow?q=%s' % (email))
+        soup = BeautifulSoup(req.content, "lxml")
+        atag = soup.findAll('a', {'class': 'title title-link antialiased j-slideshow-title'})
+        for at in atag:
+            slides[at.text] = at['href']
+    except Exception as ex:
+        print ex
     return slides
 
 


### PR DESCRIPTION
Hello! On requests to Clearbit API in emailOsint.py I got "Failed to connect to person.clearbit.com port 443: Connection refused", so after a little research on Clearbit docs I figured out that API v1 is not available any more. So I made a tiny change in **email_clearbit.py**, so now it works properly with v2.

One more problem I found (relevant to me as a Russian Federation citizen) is that there are not try/except blocks in email_*.py modules, so if there's any problem with http request, the whole emailOsint.py script fails. For instance, in Russian Federation slideshare.net website is blocked, so everytime email_slideshare.py fails. I didn't commit anything about it, just wanted to let you know.

P.S. Sorry if there's some misunderstanding, English is not my native language.