### PR TITLE
except e as Exception: --> except Exception as e:

### DIFF
--- a/emails/email_pastes.py
+++ b/emails/email_pastes.py
@@ -91,5 +91,5 @@ if __name__ == "__main__":
         banner()
         result = main(email)
         output(result, email)
-    except e as Exception:
+    except Exception as e:
         print e


### PR DESCRIPTION
This typo currently causes two _undefined names_...

flake8 testing of https://github.com/DataSploit/datasploit on Python 2.7.14

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./emails/email_pastes.py:94:12: F821 undefined name 'e'
    except e as Exception:
           ^
./emails/email_pastes.py:95:15: F821 undefined name 'e'
        print e
              ^
2     F821 undefined name 'e'
2
```