### PR TITLE
dep_check: stop using unsupported internal pip functions

### DIFF
--- a/dep_check.py
+++ b/dep_check.py
@@ -1,20 +1,18 @@
-import pip
+import pkg_resources
 import sys
 
 def check_dependency():
-    list_deps = []
     missing_deps = []
 
-    with open('requirements.txt') as f:
-        list_deps = f.read().splitlines()
-
-    pip_list = sorted([(i.key) for i in pip.get_installed_distributions()])
-
-    for req_dep in list_deps:
-        if req_dep not in pip_list:
-            missing_deps.append(req_dep)
+    with open('requirements.txt', 'r') as reqs_file:
+        for req_dep in reqs_file.read().splitlines():
+            try:
+                pkg_resources.get_distribution(req_dep)
+            except pkg_resources.DistributionNotFound:
+                missing_deps.append(req_dep)
 
     if missing_deps:
-        print "You are missing a module for Datasploit. Please install them using: "
-        print "pip install -r requirements.txt"
+        print "You are missing the following module(s) needed to run DataSploit:"
+        print ", ".join(missing_deps)
+        print "Please install them using: `pip install -r requirements.txt`"
         sys.exit()


### PR DESCRIPTION
`pip.get_installed_distributions()` is in internal function that was never meant to be externally called and has since been locked out by external functions.

Lets switch over to the supported function in `setuptools pkg_resources.get_distribution()` to search the installed packages.

See: https://github.com/pypa/pip/issues/5243
Fixes: https://github.com/DataSploit/datasploit/issues/255