### PR TITLE
dep_check.py: move from pip to setuptools

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,11 @@
+Forked for bugfixes:
+* supports config in /etc/datasploit
+* fixes requirements checking.
+
+In the future:
+* improve exception handling for tools which do not have a provided API(i.e.
+auto-skip/disable)
+
 [![ToolsWatch Best Tools](https://www.toolswatch.org/badges/toptools/2016.svg)](http://www.toolswatch.org/2017/02/2016-top-security-tools-as-voted-by-toolswatch-org-readers/)
 
 [![Arsenal-2017-EU](https://github.com/toolswatch/badges/blob/master/arsenal/europe/2017.svg)](http://www.toolswatch.org/2017/09/black-hat-arsenal-europe-2017-lineup/)

--- a/config_sample.py
+++ b/config_sample.py
@@ -2,6 +2,10 @@
 #added to gitignore so will not be syned
 
 #Backup in ~/Desktop/config.py_backup
+# The location of this file will be checked in order:
+# program $PWD, generally /usr/share/datasploit
+# /etc/datasploit/
+# ~/.config/datasploit/
 
 shodan_api=""
 bing_api=""

--- a/datasploit.py
+++ b/datasploit.py
@@ -45,7 +45,7 @@ def main(argv):
     config_sample_path= os.path.join(ds_dir,"config_sample.py")
     # If there is a systemwide config, use that instead
     if os.path.isfile('/etc/datasploit/config.py') is True:
-        config_file_path = '/etc/datasploit/config.py')
+        config_file_path = '/etc/datasploit/config.py'
 
     print os.path.exists(config_file_path)
     if not os.path.exists(config_file_path):

--- a/datasploit.py
+++ b/datasploit.py
@@ -46,6 +46,8 @@ def main(argv):
     # If there is a systemwide config, use that instead
     if os.path.isfile('/etc/datasploit/config.py') is True:
         config_file_path = '/etc/datasploit/config.py'
+    elif os.path.isfile(os.getenv('HOME') + '/.config/datasploit/config.py') is True:
+        config_file_path = os.getenv('HOME') + '/.config/datasploit/config.py'
 
     print os.path.exists(config_file_path)
     if not os.path.exists(config_file_path):

--- a/datasploit.py
+++ b/datasploit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import dep_check
 dep_check.check_dependency()

--- a/datasploit.py
+++ b/datasploit.py
@@ -43,6 +43,10 @@ def main(argv):
     ds_dir=os.path.dirname(os.path.realpath(__file__))
     config_file_path = os.path.join(ds_dir,"config.py")
     config_sample_path= os.path.join(ds_dir,"config_sample.py")
+    # If there is a systemwide config, use that instead
+    if os.path.isfile('/etc/datasploit/config.py') is True:
+        config_file_path = '/etc/datasploit/config.py')
+
     print os.path.exists(config_file_path)
     if not os.path.exists(config_file_path):
         print "[+] Looks like a new setup, setting up the config file."

--- a/datasploit_config.py
+++ b/datasploit_config.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import os, subprocess, tempfile
 

--- a/dep_check.py
+++ b/dep_check.py
@@ -1,4 +1,4 @@
-import pip
+import pkg_resources
 import sys
 
 def check_dependency():
@@ -8,13 +8,18 @@ def check_dependency():
     with open('requirements.txt') as f:
         list_deps = f.read().splitlines()
 
-    pip_list = sorted([(i.key) for i in pip.get_installed_distributions()])
+    # get list of installed python packages
+    pip_list = []
+    for item in pkg_resources.working_set.entry_keys:
+        pip_list += pkg_resources.working_set.entry_keys[item]
 
     for req_dep in list_deps:
         if req_dep not in pip_list:
             missing_deps.append(req_dep)
 
     if missing_deps:
-        print "You are missing a module for Datasploit. Please install them using: "
-        print "pip install -r requirements.txt"
+        print "You are missing a module for Datasploit:"
+        for module in missing_deps:
+            print module
+        print "Please install them using: pip install -r requirements.txt"
         sys.exit()

--- a/dep_check.py
+++ b/dep_check.py
@@ -5,8 +5,12 @@ def check_dependency():
     list_deps = []
     missing_deps = []
 
-    with open('requirements.txt') as f:
-        list_deps = f.read().splitlines()
+    try:
+        with open('requirements.txt') as f:
+            list_deps = f.read().splitlines()
+    except:
+	print "Cannot read requirements.txt to check for missing modules, exiting..."
+        sys.exit()
 
     # get list of installed python packages
     pip_list = []

--- a/docs/Writing_Modules.md
+++ b/docs/Writing_Modules.md
@@ -100,7 +100,7 @@ Each of these folder houses scripts of it's own kind, i.e., scripts working on d
 To write a new script for a module, there is a `template.py` located in each module directory to help you get started quickly. Following is the contents of the template.py file in the domain module:
 
 ```python
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import config as cfg

--- a/domain/domain_GooglePDF.py
+++ b/domain/domain_GooglePDF.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_censys.py
+++ b/domain/domain_censys.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import base
 import re, sys, json, time, requests
 import vault

--- a/domain/domain_checkpunkspider.py
+++ b/domain/domain_checkpunkspider.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import requests

--- a/domain/domain_dnsrecords.py
+++ b/domain/domain_dnsrecords.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_emailhunter.py
+++ b/domain/domain_emailhunter.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domain/domain_forumsearch.py
+++ b/domain/domain_forumsearch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import requests

--- a/domain/domain_github.py
+++ b/domain/domain_github.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domain/domain_googletracking.py
+++ b/domain/domain_googletracking.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domain/domain_history.py
+++ b/domain/domain_history.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_pagelinks.py
+++ b/domain/domain_pagelinks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_pastes.py
+++ b/domain/domain_pastes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domain/domain_shodan.py
+++ b/domain/domain_shodan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domain/domain_subdomains.py
+++ b/domain/domain_subdomains.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_urlscanio.py
+++ b/domain/domain_urlscanio.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import json

--- a/domain/domain_wappalyzer.py
+++ b/domain/domain_wappalyzer.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 from Wappalyzer import Wappalyzer, WebPage

--- a/domain/domain_whois.py
+++ b/domain/domain_whois.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/domain/domain_wikileaks.py
+++ b/domain/domain_wikileaks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import requests

--- a/domain/domain_zoomeye.py
+++ b/domain/domain_zoomeye.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import requests

--- a/domain/template.py
+++ b/domain/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/domainOsint.py
+++ b/domainOsint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import osint_runner

--- a/emailOsint.py
+++ b/emailOsint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import osint_runner

--- a/emails/email_basic_checks.py
+++ b/emails/email_basic_checks.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/emails/email_clearbit.py
+++ b/emails/email_clearbit.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/emails/email_fullcontact.py
+++ b/emails/email_fullcontact.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import requests

--- a/emails/email_hacked_emails.py
+++ b/emails/email_hacked_emails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/emails/email_haveibeenpwned.py
+++ b/emails/email_haveibeenpwned.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/emails/email_pastes.py
+++ b/emails/email_pastes.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/emails/email_scribd.py
+++ b/emails/email_scribd.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import re

--- a/emails/email_slideshare.py
+++ b/emails/email_slideshare.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/emails/email_whoismind.py
+++ b/emails/email_whoismind.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/emails/template.py
+++ b/emails/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/ip/ip_shodan.py
+++ b/ip/ip_shodan.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/ip/ip_virustotal.py
+++ b/ip/ip_virustotal.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/ip/ip_whois.py
+++ b/ip/ip_whois.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 from ipwhois import IPWhois
 import sys

--- a/ip/template.py
+++ b/ip/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/ipOsint.py
+++ b/ipOsint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import osint_runner

--- a/username/template.py
+++ b/username/template.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/username/username_gitemails.py
+++ b/username/username_gitemails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/username/username_gitlabdetails.py
+++ b/username/username_gitlabdetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 import base
 import sys
 from termcolor import colored

--- a/username/username_gitscrape.py
+++ b/username/username_gitscrape.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/username/username_gituserdetails.py
+++ b/username/username_gituserdetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/username/username_keybase.py
+++ b/username/username_keybase.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/username/username_profilepic.py
+++ b/username/username_profilepic.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import os

--- a/username/username_redditdetails.py
+++ b/username/username_redditdetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import json

--- a/username/username_tinder.py
+++ b/username/username_tinder.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import os

--- a/username/username_traviscidetails.py
+++ b/username/username_traviscidetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # Credits: https://github.com/int0x80/tcispy
 

--- a/username/username_twitterdetails.py
+++ b/username/username_twitterdetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/username/username_usernamesearch.py
+++ b/username/username_usernamesearch.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import sys

--- a/username/username_youtubedetails.py
+++ b/username/username_youtubedetails.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import base
 import vault

--- a/usernameOsint.py
+++ b/usernameOsint.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import sys
 import osint_runner


### PR DESCRIPTION
I updated dep_check.py to work on modern systems. Related to bug report here:

https://github.com/DataSploit/datasploit/issues/268

dep_check.py in this version uses pkg_resources from the setuptools package instead of pip which no longer works on modern versions of python.

In addition, this new version of dep_check.py prints missing dependencies.

tested working on Python 2.7
$ python2 --version
Python 2.7.15
