### PR TITLE
Missing dependency added to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -3,6 +3,7 @@ beautifulsoup
 beautifulsoup4
 billiard
 bs4
+cfscrape
 clearbit
 config
 configobj


### PR DESCRIPTION
While executing the python emailOsint.py the following error occured:
ImportError: No module named cfscrape

Adding the missing module fixed it :)